### PR TITLE
Refactored RegionsExtensions and added DescriptiveInfo toggle

### DIFF
--- a/EditorHelper2/Extensions/Level/Visibility/RegionsExtension.cs
+++ b/EditorHelper2/Extensions/Level/Visibility/RegionsExtension.cs
@@ -1,8 +1,10 @@
 ﻿using System.IO;
 using System.Reflection;
 using DanielWillett.UITools.API.Extensions;
+using DanielWillett.UITools.API.Extensions.Members;
 using EditorHelper2.common.API.Attributes;
 using EditorHelper2.common.API.Interfaces;
+using EditorHelper2.UI.Builders;
 using SDG.Unturned;
 using UnityEngine;
 
@@ -15,7 +17,17 @@ public class RegionsExtension : UIExtension, IExtension
     /// <summary>
     /// Size of the area of Regions shown with a RegionBorder. Vanilla uses 7x7 for Region Labels but 1x1 looks better for RegionBorders
     /// </summary>
-    private const int DebugSize = 1;
+    private const int DEBUG_SIZE = 1;
+
+    [ExistingMember("container")]
+    private readonly SleekFullscreenBox? _container;
+    [ExistingMember("regionLabels")]
+    private readonly ISleekLabel[]? _regionLabels;
+
+    private readonly ISleekLabel _toggleDescriptiveInfo;
+    private ISleekLabel? _targetRegionLabel;
+    private string? _targetRegionLabelText;
+    private bool _wantsDescriptiveInfo;
 
     private readonly Transform?[] _regionBorders;
     private readonly AssetBundle? _regionBorderBundle;
@@ -23,10 +35,19 @@ public class RegionsExtension : UIExtension, IExtension
     
     public RegionsExtension()
     {
+        UIBuilder builder = new UIBuilder(0f, 30f)
+            .SetAnchorVertical(1f)
+            .SetScaleHorizontal(1f)
+            .SetOffsetVertical(-40f)
+            .SetText($"Hold [{MenuConfigurationControlsUI.getKeyCodeText(ControlsSettings.snap)}] to show descriptive information");
+
+        _toggleDescriptiveInfo = builder.BuildLabel();
+        _toggleDescriptiveInfo.TextContrastContext = ETextContrastContext.ColorfulBackdrop;
+
         Assembly assembly = Assembly.GetExecutingAssembly();
         string bundlePath = Path.Combine(Path.GetDirectoryName(assembly.Location) ?? string.Empty, "Assets" ,"RegionBorder.unity3d");
 
-        _regionBorders = new Transform[DebugSize * DebugSize];
+        _regionBorders = new Transform[DEBUG_SIZE * DEBUG_SIZE];
 
         _regionBorderBundle = AssetBundle.LoadFromFile(bundlePath);
         if (_regionBorderBundle == null)
@@ -47,6 +68,11 @@ public class RegionsExtension : UIExtension, IExtension
 
     public void Initialize()
     {
+        _container?.AddChild(_toggleDescriptiveInfo);
+
+        if (_regionLabels != null)
+            _targetRegionLabel = _regionLabels[_regionLabels.Length / 2];
+
         if (_regionBorderPrefab == null) return;
 
         const float REGION_HEIGHT = 1024f / 4f; // Doesn't seem to change anything, ask Sultan
@@ -62,39 +88,71 @@ public class RegionsExtension : UIExtension, IExtension
         }
     }
 
+    internal void CustomUpdate()
+    {
+        if (_targetRegionLabel == null) return;
+
+        _wantsDescriptiveInfo = InputEx.GetKey(ControlsSettings.snap);
+
+        if (_wantsDescriptiveInfo && _targetRegionLabelText == null)
+        {
+            _targetRegionLabelText = _targetRegionLabel.Text;
+
+            string[] lines = _targetRegionLabelText.Split('\n');
+            lines[1] = "Objects: " + lines[1] + " of all";
+            lines[2] = "Triangles: " + lines[2];
+
+            _targetRegionLabel.Text = string.Join('\n', lines);
+        }
+        else if (!_wantsDescriptiveInfo && _targetRegionLabelText != null)
+        {
+            _targetRegionLabel.Text = _targetRegionLabelText;
+            _targetRegionLabelText = null;
+        }
+    }
+
     internal void CustomUpdateRegion(int cameraRegionX, int cameraRegionY)
     {
-        if (_regionBorderPrefab == null || DebugSize < 1) return;
+        if (_targetRegionLabel != null && _wantsDescriptiveInfo)
+        {
+            _targetRegionLabelText = _targetRegionLabel.Text;
+
+            string[] lines = _targetRegionLabelText.Split('\n');
+            lines[1] = "Objects: " + lines[1] + " of all";
+            lines[2] = "Triangles: " + lines[2];
+
+            _targetRegionLabel.Text = string.Join('\n', lines);
+        }
+
+        if (_regionBorderPrefab == null || DEBUG_SIZE < 1) return;
 
         // Loop through the grid around the camera's current region
-        for (int i = -DebugSize / 2; i <= DebugSize / 2; i++)
+        for (int i = -DEBUG_SIZE / 2; i <= DEBUG_SIZE / 2; i++)
         {
-            for (int j = -DebugSize / 2; j <= DebugSize / 2; j++)
+            for (int j = -DEBUG_SIZE / 2; j <= DEBUG_SIZE / 2; j++)
             {
                 byte x = (byte)(cameraRegionX + i);
                 byte y = (byte)(cameraRegionY + j);
 
-                // Make sure we are within valid region bounds
-                if (x < Regions.WORLD_SIZE && y < Regions.WORLD_SIZE)
+                if (!Regions.checkSafe(x, y)) continue;
+
+                Vector3 regionPosition = new(
+                    (x * Regions.REGION_SIZE) + (Regions.REGION_SIZE / 2) - (Regions.WORLD_SIZE * (Regions.REGION_SIZE / 2)),
+                    0,
+                    (y * Regions.REGION_SIZE) + (Regions.REGION_SIZE / 2) - (Regions.WORLD_SIZE * (Regions.REGION_SIZE / 2))
+                );
+
+                Transform? regionBorder = _regionBorders[((i + (DEBUG_SIZE / 2)) * DEBUG_SIZE) + j + (DEBUG_SIZE / 2)];
+                if (regionBorder == null)
                 {
-                    Vector3 regionPosition = new(
-                        (x * Regions.REGION_SIZE) + (Regions.REGION_SIZE / 2) - (Regions.WORLD_SIZE * (Regions.REGION_SIZE / 2)),
-                        0,
-                        (y * Regions.REGION_SIZE) + (Regions.REGION_SIZE / 2) - (Regions.WORLD_SIZE * (Regions.REGION_SIZE / 2))
-                    );
-
-                    Transform? regionBorder = _regionBorders[((i + (DebugSize / 2)) * DebugSize) + j + (DebugSize / 2)];
-                    if (regionBorder == null)
-                    {
-                        UnturnedLog.info($"RegionsExtension: {nameof(regionBorder)} is somehow null? This should never happen");
-                        // This isn't a continue because this should be treated as an NullReferenceException
-                        // It would also spam the Logs if the entire _regionBorders is null
-                        return;
-                    }
-
-                    regionBorder.position = regionPosition;
-                    regionBorder.gameObject.SetActive(true);
+                    UnturnedLog.info($"RegionsExtension: {nameof(regionBorder)} is somehow null? This should never happen");
+                    // This isn't a continue because this should be treated as an NullReferenceException
+                    // It would also spam the Logs if the entire _regionBorders is null
+                    return;
                 }
+
+                regionBorder.position = regionPosition;
+                regionBorder.gameObject.SetActive(true);
             }
         }
     }
@@ -110,6 +168,8 @@ public class RegionsExtension : UIExtension, IExtension
 
     public void Dispose()
     {
+        _targetRegionLabel = null;
+
         foreach (Transform? regionBorder in _regionBorders)
         {
             if (regionBorder == null) continue;

--- a/EditorHelper2/Extensions/Level/Visibility/RegionsExtension.cs
+++ b/EditorHelper2/Extensions/Level/Visibility/RegionsExtension.cs
@@ -8,20 +8,25 @@ using UnityEngine;
 
 namespace EditorHelper2.Extensions.Level.Visibility;
 
-[EHExtension("Regions Extension", "JienSultan")]
+[EHExtension("Regions Extension", "JienSultan & Gamingtoday093")]
 [UIExtension(typeof(EditorLevelVisibilityUI))]
 public class RegionsExtension : UIExtension, IExtension
 {
+    /// <summary>
+    /// Size of the area of Regions shown with a RegionBorder. Vanilla uses 7x7 for Region Labels but 1x1 looks better for RegionBorders
+    /// </summary>
     private const int DebugSize = 1;
-    private Camera? _mainCamera;
-    private readonly Transform? _regionBordersParent;
+
+    private readonly Transform?[] _regionBorders;
     private readonly AssetBundle? _regionBorderBundle;
     private readonly GameObject? _regionBorderPrefab;
     
     public RegionsExtension()
     {
         Assembly assembly = Assembly.GetExecutingAssembly();
-        string bundlePath = Path.Combine(Path.GetDirectoryName(assembly.Location) ?? string.Empty, "Assets" ,"RegionBorder.unity3d"); 
+        string bundlePath = Path.Combine(Path.GetDirectoryName(assembly.Location) ?? string.Empty, "Assets" ,"RegionBorder.unity3d");
+
+        _regionBorders = new Transform[DebugSize * DebugSize];
 
         _regionBorderBundle = AssetBundle.LoadFromFile(bundlePath);
         if (_regionBorderBundle == null)
@@ -37,33 +42,31 @@ public class RegionsExtension : UIExtension, IExtension
             return;
         }
 
-        _regionBordersParent = new GameObject("RegionBorders").transform; // Create a parent for clips
-        
         Initialize();
     }
 
     public void Initialize()
     {
-        _mainCamera = Camera.main;
+        if (_regionBorderPrefab == null) return;
+
+        const float REGION_HEIGHT = 1024f / 4f; // Doesn't seem to change anything, ask Sultan
+
+        for (int i = 0; i < _regionBorders.Length; i++)
+        {
+            Transform regionBorder = Object.Instantiate(_regionBorderPrefab).transform;
+            regionBorder.name = "EditorHelper:RegionBorder";
+            regionBorder.localScale = new Vector3(Regions.REGION_SIZE, REGION_HEIGHT, Regions.REGION_SIZE);
+            regionBorder.gameObject.SetActive(false);
+
+            _regionBorders[i] = regionBorder;
+        }
     }
 
-    #region Extension Functions
-    internal void CustomUpdate()
+    internal void CustomUpdateRegion(int cameraRegionX, int cameraRegionY)
     {
-        if (_mainCamera == null) return;
+        if (_regionBorderPrefab == null || DebugSize < 1) return;
 
-        float regionSize = Regions.REGION_SIZE;
-        Vector3 cameraPosition = _mainCamera.transform.position;
-
-        // Get the current region of the camera
-        if (!Regions.tryGetCoordinate(cameraPosition, out byte cameraRegionX, out byte cameraRegionY))
-            return;
-
-        // Remove previous clips to prevent duplicates
-        foreach (Transform child in _regionBordersParent!)
-            Object.Destroy(child.gameObject);
-
-        // Loop through the 7x7 grid around the camera's current region
+        // Loop through the grid around the camera's current region
         for (int i = -DebugSize / 2; i <= DebugSize / 2; i++)
         {
             for (int j = -DebugSize / 2; j <= DebugSize / 2; j++)
@@ -74,44 +77,45 @@ public class RegionsExtension : UIExtension, IExtension
                 // Make sure we are within valid region bounds
                 if (x < Regions.WORLD_SIZE && y < Regions.WORLD_SIZE)
                 {
-                    Vector3 regionPosition = new Vector3(
-                        (x * regionSize) + (regionSize / 2) - (Regions.WORLD_SIZE * (regionSize / 2)),
+                    Vector3 regionPosition = new(
+                        (x * Regions.REGION_SIZE) + (Regions.REGION_SIZE / 2) - (Regions.WORLD_SIZE * (Regions.REGION_SIZE / 2)),
                         0,
-                        (y * regionSize) + (regionSize / 2) - (Regions.WORLD_SIZE * (regionSize / 2))
+                        (y * Regions.REGION_SIZE) + (Regions.REGION_SIZE / 2) - (Regions.WORLD_SIZE * (Regions.REGION_SIZE / 2))
                     );
 
-                    // Create and configure the world border
-                    RegionBorders(regionPosition, regionSize);
+                    Transform? regionBorder = _regionBorders[((i + (DebugSize / 2)) * DebugSize) + j + (DebugSize / 2)];
+                    if (regionBorder == null)
+                    {
+                        UnturnedLog.info($"RegionsExtension: {nameof(regionBorder)} is somehow null? This should never happen");
+                        // This isn't a continue because this should be treated as an NullReferenceException
+                        // It would also spam the Logs if the entire _regionBorders is null
+                        return;
+                    }
+
+                    regionBorder.position = regionPosition;
+                    regionBorder.gameObject.SetActive(true);
                 }
             }
         }
     }
-    
-    private void RegionBorders(Vector3 position, float size)
-    {
-        float height = 1024;
 
-        if (_regionBorderPrefab != null)
+    protected override void Closed()
+    {
+        foreach (Transform? regionBorder in _regionBorders)
         {
-            Transform wall = (Object.Instantiate(_regionBorderPrefab)).transform;
-            wall.position = position;
-            wall.localScale = new Vector3(size, height / 4f, size);
-            wall.name = "RegionBorder";
-            wall.parent = _regionBordersParent;
+            if (regionBorder == null) continue;
+            regionBorder.gameObject.SetActive(false);
         }
     }
 
-    #endregion Extension Functions
-
     public void Dispose()
     {
-        for (int i = 0; i < _regionBordersParent!.childCount; i++)
+        foreach (Transform? regionBorder in _regionBorders)
         {
-            Transform child = _regionBordersParent.GetChild(i);
-            Object.Destroy(child.gameObject);
+            if (regionBorder == null) continue;
+            Object.Destroy(regionBorder.gameObject);
         }
-        Object.Destroy(_regionBordersParent);
 
-        _regionBorderBundle!.Unload(true);
+        _regionBorderBundle?.Unload(true);
     }
 }

--- a/EditorHelper2/Patches/Editor/UI/EditorLevelVisibilityUIPatches.cs
+++ b/EditorHelper2/Patches/Editor/UI/EditorLevelVisibilityUIPatches.cs
@@ -9,11 +9,11 @@ namespace EditorHelper2.Patches.Editor.UI;
 [HarmonyPatch(typeof(EditorLevelVisibilityUI))]
 public class EditorLevelVisibilityUIPatches
 {
-    [HarmonyPatch(nameof(EditorLevelVisibilityUI.update), new Type[] { })]
+    [HarmonyPatch(nameof(EditorLevelVisibilityUI.update), new Type[] { typeof(int), typeof(int) })]
     [HarmonyPostfix]
     [UsedImplicitly]
-    public static void PostfixUpdate()
+    public static void PostfixUpdateRegion(int x, int y)
     {
-        EditorLevelVisibilityUIUpdate.Update();
+        EditorLevelVisibilityUIUpdate.UpdateRegion(x, y);
     }
 }

--- a/EditorHelper2/Patches/Editor/UI/EditorLevelVisibilityUIPatches.cs
+++ b/EditorHelper2/Patches/Editor/UI/EditorLevelVisibilityUIPatches.cs
@@ -9,7 +9,15 @@ namespace EditorHelper2.Patches.Editor.UI;
 [HarmonyPatch(typeof(EditorLevelVisibilityUI))]
 public class EditorLevelVisibilityUIPatches
 {
-    [HarmonyPatch(nameof(EditorLevelVisibilityUI.update), new Type[] { typeof(int), typeof(int) })]
+    [HarmonyPatch(nameof(EditorLevelVisibilityUI.update), [])]
+    [HarmonyPostfix]
+    [UsedImplicitly]
+    public static void PostfixUpdate()
+    {
+        EditorLevelVisibilityUIUpdate.Update();
+    }
+
+    [HarmonyPatch(nameof(EditorLevelVisibilityUI.update), [typeof(int), typeof(int)])]
     [HarmonyPostfix]
     [UsedImplicitly]
     public static void PostfixUpdateRegion(int x, int y)

--- a/EditorHelper2/Updates/Editor/EditorLevelVisibilityUIUpdate.cs
+++ b/EditorHelper2/Updates/Editor/EditorLevelVisibilityUIUpdate.cs
@@ -5,6 +5,16 @@ namespace EditorHelper2.Updates.Editor;
 
 public static class EditorLevelVisibilityUIUpdate
 {
+    public static void Update()
+    {
+        #region RegionsExtension
+        if (ExtensionManager.TryGetInstance(out RegionsExtension? regionsExtension))
+        {
+            regionsExtension.CustomUpdate();
+        }
+        #endregion RegionsExtension
+    }
+
     public static void UpdateRegion(int x, int y)
     {
         #region RegionsExtension

--- a/EditorHelper2/Updates/Editor/EditorLevelVisibilityUIUpdate.cs
+++ b/EditorHelper2/Updates/Editor/EditorLevelVisibilityUIUpdate.cs
@@ -5,12 +5,12 @@ namespace EditorHelper2.Updates.Editor;
 
 public static class EditorLevelVisibilityUIUpdate
 {
-    public static void Update()
+    public static void UpdateRegion(int x, int y)
     {
         #region RegionsExtension
         if (ExtensionManager.TryGetInstance(out RegionsExtension? regionsExtension))
         {
-            regionsExtension.CustomUpdate();
+            regionsExtension.CustomUpdateRegion(x, y);
         }
         #endregion RegionsExtension
     }


### PR DESCRIPTION
Refactored RegionsExtension to not instantiate and destroy RegionBorders every frame and fixed not clearing the RegionBorders when leaving the Visibility Tab. Added Descriptive Information for the Visibility Values that can be toggled by holding Snap (Left Control by default).

<img width="1257" height="707" alt="DescriptiveInfoPreview" src="https://github.com/user-attachments/assets/784f6d26-c5fd-4d46-a939-a989f2e47bb6" />
