### PR TITLE
Fixed Rendering Charts that dont have an aspect of 1:1

### DIFF
--- a/EditorHelper2/Patches/Level/LevelPatches.cs
+++ b/EditorHelper2/Patches/Level/LevelPatches.cs
@@ -360,7 +360,7 @@ public class LevelPatches
                         color.a = 1f;
                         pixels[y] = color;
                     }
-                    texture2D.SetPixels(x, 0, 1, imageWidth, pixels);
+                    texture2D.SetPixels(x, 0, 1, imageHeight, pixels);
                 }
             }
             finally


### PR DESCRIPTION
Oops seems like I used the wrong dimension for SetPixels()