### PR TITLE
Refactored Singleplayer Extension and Fixed an issue with Prompts Extension

### DIFF
--- a/EditorHelper2.common/Helpers/SingleplayerSharedClass.cs
+++ b/EditorHelper2.common/Helpers/SingleplayerSharedClass.cs
@@ -6,6 +6,7 @@ namespace EditorHelper2.common.Helpers;
 public static class SingleplayerSharedClass
 {
     public static Vector3 CameraPosition = Vector3.zero;
+    public static float CameraRotation = 0f;
 
     public static LevelInfo? LevelInfo = null;
 }

--- a/EditorHelper2/Extensions/Editor/Dashboard/PromptsExtension.cs
+++ b/EditorHelper2/Extensions/Editor/Dashboard/PromptsExtension.cs
@@ -25,11 +25,11 @@ public class PromptsExtension : UIExtension, IExtension
     /// <summary>
     /// Action executed if the answer is positive
     /// </summary>
-    private Action _questionAction;
+    private Action? _questionAction;
     /// <summary>
     /// Action executed after the user answer.
     /// </summary>
-    private Action _questionPostAction;
+    private Action? _questionPostAction;
     
     public PromptsExtension()
     {
@@ -100,7 +100,7 @@ public class PromptsExtension : UIExtension, IExtension
     
     private void OnNoButtonClicked(ISleekElement button)
     {
-        _questionAction?.Invoke();
+        _questionPostAction?.Invoke();
     }
     #endregion Event handlers
 

--- a/EditorHelper2/Extensions/Editor/Dashboard/SingleplayerExtension.cs
+++ b/EditorHelper2/Extensions/Editor/Dashboard/SingleplayerExtension.cs
@@ -59,6 +59,7 @@ public class SingleplayerExtension : UIExtension, IExtension
                 {
                     SingleplayerSharedClass.LevelInfo = SDG.Unturned.Level.info;
                     SingleplayerSharedClass.CameraPosition = MainCamera.instance.transform.parent.position;
+                    SingleplayerSharedClass.CameraRotation = MainCamera.instance.transform.parent.eulerAngles.y;
                     TimeUtility.singleton.StartCoroutine(SendToSingleplayer());
                 });    
         }
@@ -73,7 +74,7 @@ public class SingleplayerExtension : UIExtension, IExtension
         yield return new WaitForEndOfFrame();
         yield return new WaitForEndOfFrame();
         yield return new WaitForEndOfFrame();
-        Provider.map = SingleplayerSharedClass.LevelInfo.name;
+        Provider.map = SingleplayerSharedClass.LevelInfo!.name;
         Provider.singleplayer(EGameMode.EASY, true);
         yield break;
     }

--- a/EditorHelper2/Extensions/PlayerUIs/EditorExtension.cs
+++ b/EditorHelper2/Extensions/PlayerUIs/EditorExtension.cs
@@ -43,8 +43,6 @@ public class EditorExtension : UIExtension, IExtension
         _editorButton.OnClicked += OnEditorClicked;
         
         _container.AddChild(_editorButton);
-
-        TimeUtility.singleton.StartCoroutine(TeleportPlayer(Player.LocalPlayer));
     }
 
     #region Event handlers
@@ -55,24 +53,15 @@ public class EditorExtension : UIExtension, IExtension
     #endregion Event handlers
 
     #region Extension Functions
-    private IEnumerator TeleportPlayer(Player player)
-    { 
-        yield return new WaitForEndOfFrame();
-        yield return new WaitForEndOfFrame();
-        yield return new WaitForEndOfFrame();
-        player.teleportToLocation(SingleplayerSharedClass.CameraPosition, 0f);
-        
-        yield break;
-    }
-    
     private IEnumerator SendToEditor()
     {
+        LevelInfo levelInfo = SingleplayerSharedClass.LevelInfo!;
         Provider.RequestDisconnect("Going back to editor");
         yield return new WaitUntil(() => SDG.Unturned.Level.isExiting == false);
         yield return new WaitForEndOfFrame();
         yield return new WaitForEndOfFrame();
         yield return new WaitForEndOfFrame();
-        SDG.Unturned.Level.edit(SingleplayerSharedClass.LevelInfo);
+        SDG.Unturned.Level.edit(levelInfo);
         yield break;
     }
     #endregion Extension Functions
@@ -84,5 +73,7 @@ public class EditorExtension : UIExtension, IExtension
         _editorButton.OnClicked -= OnEditorClicked;
 
         _container.RemoveChild(_editorButton);
+
+        SingleplayerSharedClass.LevelInfo = null;
     }
 }

--- a/EditorHelper2/Loader/ExtensionManager.cs
+++ b/EditorHelper2/Loader/ExtensionManager.cs
@@ -40,7 +40,7 @@ public static class ExtensionManager
         }
         
         EHExtensionAttribute? attribute = typeof(T).GetCustomAttribute<EHExtensionAttribute>();
-        if (attribute == null || (_instanceStatus.ContainsKey(attribute) && !_instanceStatus[attribute])) return false; // Don't return if the extension is disabled
+        if (attribute == null || (_instanceStatus.TryGetValue(attribute, out bool isEnabled) && !isEnabled)) return false; // Don't return if the extension is disabled
 
         instance = info.Instantiations.OfType<T>().LastOrDefault();
         return instance != null;
@@ -50,6 +50,14 @@ public static class ExtensionManager
     {
         return _instanceStatus.Any(c => c.Key.Name.Equals(extensionName, StringComparison.OrdinalIgnoreCase)) 
                && _instanceStatus.First(c => c.Key.Name.Equals(extensionName, StringComparison.OrdinalIgnoreCase)).Value;
+    }
+
+    public static bool IsEnabled<TExtension>() where TExtension : class
+    {
+        EHExtensionAttribute? attribute = typeof(TExtension).GetCustomAttribute<EHExtensionAttribute>();
+        if (attribute == null) return false;
+
+        return !_instanceStatus.TryGetValue(attribute, out bool isEnabled) || isEnabled; // Always enabled extensions are not in _instanceStatus
     }
     
     public static int LoadAllExtensions()

--- a/EditorHelper2/Patches/Provider/ProviderPatches.cs
+++ b/EditorHelper2/Patches/Provider/ProviderPatches.cs
@@ -1,0 +1,39 @@
+﻿using EditorHelper2.common.Helpers;
+using EditorHelper2.Extensions.Editor.Dashboard;
+using EditorHelper2.Extensions.PlayerUIs;
+using EditorHelper2.Loader;
+using HarmonyLib;
+using JetBrains.Annotations;
+using SDG.Unturned;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace EditorHelper2.Patches.Provider;
+
+[HarmonyPatch(typeof(SDG.Unturned.Provider))]
+public class ProviderPatches
+{
+    [HarmonyPatch("loadPlayerSpawn")]
+    [HarmonyPostfix]
+    [UsedImplicitly]
+    private static void LoadPlayerSpawnPostfix(SteamPlayerID playerID, ref Vector3 point, ref byte angle, ref EPlayerStance initialStance)
+    {
+        if (ExtensionManager.IsEnabled<SingleplayerExtension>() &&
+            SingleplayerSharedClass.LevelInfo != null && SingleplayerSharedClass.LevelInfo.Equals(SDG.Unturned.Level.info))
+        {
+            const int layerMask = RayMasks.LARGE | RayMasks.MEDIUM | RayMasks.GROUND | RayMasks.RESOURCE | RayMasks.ENVIRONMENT | RayMasks.BARRICADE | RayMasks.STRUCTURE;
+            if (Physics.Raycast(SingleplayerSharedClass.CameraPosition, Vector3.down, out var hit, PlayerMovement.HEIGHT_STAND, layerMask, QueryTriggerInteraction.Ignore))
+                point = hit.point + new Vector3(0f, 0.1f, 0f);
+            else
+                point = SingleplayerSharedClass.CameraPosition - new Vector3(0f, PlayerMovement.HEIGHT_STAND, 0f);
+
+            PlayerStance.getStanceForPosition(point, ref initialStance);
+
+            angle = MeasurementTool.angleToByte(SingleplayerSharedClass.CameraRotation);
+
+            if (!ExtensionManager.IsEnabled<EditorExtension>()) SingleplayerSharedClass.LevelInfo = null;
+        }
+    }
+}

--- a/EditorHelper2/Patches/UI/MenuDashboardUIPatches.cs
+++ b/EditorHelper2/Patches/UI/MenuDashboardUIPatches.cs
@@ -12,7 +12,7 @@ public class MenuDashboardUIPatches
     [UsedImplicitly]
     private static bool OnClickedBattlEyeButton(ISleekElement element)
     {
-        Provider.provider.browserService.open("https://discord.gg/Y3jD5K2Q8C");
+        SDG.Unturned.Provider.provider.browserService.open("https://discord.gg/Y3jD5K2Q8C");
 
         return false;
     }


### PR DESCRIPTION
Singleplayer Extension has been rewritten to not depend on Editor Extension and now always places you at the Camera position. Also fixed a small issue in the Prompts Extension and added a new overload for `ExtensionManager.IsEnabled()` that takes a generic. I am not sure about the Provider namespace I've introduced with ProviderPatches. It can easily be changed if need be.