### PR TITLE
Fixed UpdaterCore Race conditions

### DIFF
--- a/EditorHelper2.common/Helpers/UpdaterCore.cs
+++ b/EditorHelper2.common/Helpers/UpdaterCore.cs
@@ -16,6 +16,13 @@ public enum EVersionStatus
     Latest
 }
 
+public enum EGetLatestVersionResult
+{
+    Loading,
+    Failed,
+    Success
+}
+
 // Originally based on https://github.com/ShimmyMySherbet/ShimmysAdminTools/blob/master/ShimmysAdminTools/Components/UpdaterCore.cs
 public static class UpdaterCore
 {
@@ -27,8 +34,15 @@ public static class UpdaterCore
     private static readonly SemaphoreSlim _requestLock = new SemaphoreSlim(1, 1);
 
     private static IniFile? _globalConfig = null;
-    private static bool _loadedConfig = false;
-    public static bool ConfigLoaded => _loadedConfig;
+    public static bool ConfigLoaded()
+    {
+        if (_requestLock.Wait(0))
+        {
+            _requestLock.Release();
+            return true;
+        }
+        return false;
+    }
     public static event Action? OnConfigLoaded;
 
     private static readonly Version CurrentVersion = typeof(UpdaterCore).Assembly.GetName().Version;
@@ -38,7 +52,6 @@ public static class UpdaterCore
         await _requestLock.WaitAsync(cancellationToken);
         try
         {
-            _loadedConfig = false;
             _globalConfig = null;
 
             using (var response = await _client.GetAsync(GlobalConfigURL, cancellationToken))
@@ -49,8 +62,6 @@ public static class UpdaterCore
                     _globalConfig = new IniFile(config);
                 }
             }
-
-            _loadedConfig = true;
 
             // This should be Awaited instead of Fire & Forget because otherwise _globalConfig and _loadedConfig could be invalid (null and false, when the event is dispatched on the Main thread)
             await TaskDispatcher.QueueOnMainThreadAsync(() =>
@@ -63,8 +74,13 @@ public static class UpdaterCore
 
     public static EVersionStatus GetVersionStatus()
     {
-        if (!ConfigLoaded) return EVersionStatus.Loading;
-        if (!TryGetLatestVersion(out Version latestVersion)) return EVersionStatus.Unknown;
+        switch (TryGetLatestVersion(out Version latestVersion))
+        {
+            case EGetLatestVersionResult.Loading:
+                return EVersionStatus.Loading;
+            case EGetLatestVersionResult.Failed:
+                return EVersionStatus.Unknown;
+        }
         if (latestVersion > CurrentVersion) return EVersionStatus.Outdated;
         return EVersionStatus.Latest;
     }
@@ -78,30 +94,43 @@ public static class UpdaterCore
         title = null;
         subtitle = null;
 
-        if (ConfigLoaded && _globalConfig != null &&
-            _globalConfig.KeySet("UpdateMessage") &&
-            _globalConfig.KeySet("Title") &&
-            _globalConfig.KeySet("Subtitle"))
-        {
-            message = _globalConfig["UpdateMessage"].Replace("\\n", "\n");
-            title = _globalConfig["Title"].Replace("\\n", "\n");
-            subtitle = _globalConfig["Subtitle"].Replace("\\n", "\n");
-            return true;
-        }
+        if (!_requestLock.Wait(0)) return false;
 
-        return false;
+        try
+        {
+            if (_globalConfig != null &&
+                _globalConfig.KeySet("UpdateMessage") &&
+                _globalConfig.KeySet("Title") &&
+                _globalConfig.KeySet("Subtitle"))
+            {
+                message = _globalConfig["UpdateMessage"].Replace("\\n", "\n");
+                title = _globalConfig["Title"].Replace("\\n", "\n");
+                subtitle = _globalConfig["Subtitle"].Replace("\\n", "\n");
+                return true;
+            }
+
+            return false;
+        }
+        finally { _requestLock.Release(); }
     }
 
-    public static bool TryGetLatestVersion(out Version latestVersion)
+    public static EGetLatestVersionResult TryGetLatestVersion(out Version latestVersion)
     {
-        if (ConfigLoaded && _globalConfig != null &&
-            _globalConfig.KeySet("LatestVersion") && Version.TryParse(_globalConfig["LatestVersion"], out latestVersion))
-        {
-            return true;
-        }
-
         latestVersion = CurrentVersion;
-        return false;
+
+        if (!_requestLock.Wait(0)) return EGetLatestVersionResult.Loading;
+
+        try
+        {
+            if (_globalConfig != null &&
+                _globalConfig.KeySet("LatestVersion") && Version.TryParse(_globalConfig["LatestVersion"], out latestVersion))
+            {
+                return EGetLatestVersionResult.Success;
+            }
+
+            return EGetLatestVersionResult.Failed;
+        }
+        finally { _requestLock.Release(); }
     }
 
     public static Version LatestVersion

--- a/EditorHelper2/Extensions/Menu/NewsExtension.cs
+++ b/EditorHelper2/Extensions/Menu/NewsExtension.cs
@@ -141,7 +141,7 @@ public class NewsExtension : UIExtension, IExtension
         MenuUI.container.AddChild(_updateRequiredBox);
         MenuDashboardUI.mainScrollView.AddChild(_updateBox);
 
-        if (UpdaterCore.ConfigLoaded) VersionStatusReady();
+        if (UpdaterCore.ConfigLoaded()) VersionStatusReady();
         UpdaterCore.OnConfigLoaded += VersionStatusReady; // Allow for Realtime Updating
     }
 


### PR DESCRIPTION
Fixed a couple of race conditions in `UpdaterCore`. Now it will instead try to enter the Lock in a non-blocking manner when accessing the config from the main thread to make sure that it can't be invalid